### PR TITLE
Add circleci context info

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,12 +9,17 @@ jobs:
       - image: cimg/python:3.8
         environment:
           DJANGO_SETTINGS_MODULE: chowist.settings.test
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
       - image: postgres:12
         environment:
           POSTGRES_USER: circleci
           POSTGRES_PASSWORD: circleci
           POSTGRES_DB: circle_test
-
+        auth:
+          username: $DOCKERHUB_USERNAME
+          password: $DOCKERHUB_PASSWORD
     steps:
       - checkout
       - python/install-packages:
@@ -28,4 +33,5 @@ jobs:
 workflows:
   main:
     jobs:
-      - build-and-test
+      - build-and-test:
+          context: docker-hub-creds


### PR DESCRIPTION
As per https://circleci.com/docs/2.0/private-images/, this seems like a good thing to do to raise Docker pull limits on CircleCI builds.