### PR TITLE
Update to Python 3.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ orbs:
 jobs:
   build-and-test:
     docker:
-      - image: cimg/python:3.10
+      - image: cimg/python:3.11
         environment:
           DJANGO_SETTINGS_MODULE: chowist.settings.test
         auth:

--- a/build/django.Dockerfile
+++ b/build/django.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8-alpine
+FROM python:3.11-alpine
 ENV PYTHONUNBUFFERED 1
 ENV PIP_NO_BINARY psycopg2
 WORKDIR /app


### PR DESCRIPTION
https://devguide.python.org/versions/ - looks like Python 3.11 will be supported for a while. Let's move over to that version, given that Python 3.8 will EOL in a year or two.