### PR TITLE
Update Django to 4.2.5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 crispy-bootstrap5==0.7
-Django==4.2.4
+Django==4.2.5
 django-crispy-forms==2.0
 gunicorn==21.2.0
 psycopg2-binary==2.9.7


### PR DESCRIPTION
With https://docs.djangoproject.com/en/4.2/releases/4.2.5/ it's time to upgrade dependencies!