### PR TITLE
Update Postgres to 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     services:
       postgres:
         # Docker Hub image
-        image: postgres:14
+        image: postgres:16
         # Provide the credentials
         env:
           POSTGRES_USER: github

--- a/compose/dev.yml
+++ b/compose/dev.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   db:
-    image: 'postgres:14-alpine'
+    image: 'postgres:16-alpine'
     volumes:
       - '/var/lib/postgresql/data'
     restart: always


### PR DESCRIPTION
Nothing complicated. Just figured that Postgres 14 was deprecated and we should get to the more recent versions. Granted 17 just came out but let's just wait a little bit before moving on.